### PR TITLE
Fix minimum requirement version

### DIFF
--- a/systemd.el
+++ b/systemd.el
@@ -4,7 +4,7 @@
 
 ;; Author: Mark Oteiza <mvoteiza@udel.edu>
 ;; Version: 1.2
-;; Package-Requires: ((emacs "24.3"))
+;; Package-Requires: ((emacs "24.4"))
 ;; Keywords: tools, unix
 
 ;; This file is free software; you can redistribute it and/or


### PR DESCRIPTION
'with-eval-after-load' was introduced at Emacs 24.4.
(If you don't want to update minimum Emacs version, you should rewrite `with-eval-after-load` with `eval-after-load`.)