### PR TITLE
Add %S, %C, %L specifiers

### DIFF
--- a/systemd.el
+++ b/systemd.el
@@ -337,7 +337,7 @@ See `font-lock-keywords' and (info \"(elisp) Search-based Fontification\")."
      ("\\$[A-Z_]+\\>"
       (systemd-value-extend-region) nil (0 'font-lock-variable-name-face))
      ;; specifiers
-     ("%[nNpPiIfcrRtuUhsmbHv%]"
+     ("%[nNpPiIfcrRtSCLuUhsmbHv%]"
       (systemd-value-extend-region) nil (0 'font-lock-constant-face))))
   "Extended expressions to highlight in `systemd-mode'.")
 


### PR DESCRIPTION
These specifiers for the state, cache, and log directory root were added in systemd v236.

---

Thanks for creating this mode, by the way :heart: