### PR TITLE
added capf for env. variables

### DIFF
--- a/systemd.el
+++ b/systemd.el
@@ -230,21 +230,32 @@ file, defaulting to the link under point, if any."
       (if sectionp systemd-network-sections systemd-network-directives))
      (t (if sectionp systemd-unit-sections systemd-unit-directives)))))
 
+(defun systemd-env-variable-table (&rest _ignore)
+  "Completion table with environment variables."
+  (mapcar (lambda (x) (substring x 0 (string-match "=" x))) process-environment))
+
 (defun systemd-complete-at-point ()
   "Complete the symbol at point."
-  (let ((bounds (bounds-of-thing-at-point 'symbol)))
-    (list (or (car bounds) (point))
-          (or (cdr bounds) (point))
-          (completion-table-dynamic #'systemd-completion-table))))
+  (when-let* ((bounds (bounds-of-thing-at-point 'symbol)))
+    (list (car bounds) (cdr bounds)
+          (completion-table-in-turn
+           (completion-table-dynamic #'systemd-completion-table)
+           (completion-table-dynamic #'systemd-env-variable-table))
+          :exit-function
+          (lambda (_ finished)
+            (when (and (not (systemd-buffer-section-p))
+                       (memq finished '(sole finished)))
+              (insert "="))))))
 
-(defun systemd-company-backend (command &optional arg &rest ignored)
-  "Backend for `company-mode' in `systemd-mode' buffers."
-  (interactive (list 'interactive))
-  (pcase command
-    (`interactive (company-begin-backend 'systemd-company-backend))
-    (`prefix (and (eq major-mode 'systemd-mode) (company-grab-symbol)))
-    (`candidates (all-completions arg (systemd-completion-table nil)))
-    (`post-completion (if (not (systemd-buffer-section-p)) (insert "=")))))
+;; Note: company-capf can take over here
+;; (defun systemd-company-backend (command &optional arg &rest ignored)
+;;   "Backend for `company-mode' in `systemd-mode' buffers."
+;;   (interactive (list 'interactive))
+;;   (pcase command
+;;     (`interactive (company-begin-backend 'systemd-company-backend))
+;;     (`prefix (and (eq major-mode 'systemd-mode) (company-grab-symbol)))
+;;     (`candidates (all-completions arg (systemd-completion-table nil)))
+;;     (`post-completion (if (not (systemd-buffer-section-p)) (insert "=")))))
 
 (defun systemd-construct-start-p ()
   "Return non-nil if the current line is the first in a multi-line construct."
@@ -407,7 +418,9 @@ Key bindings:
   (set-keymap-parent systemd-mode-map nil)
   (conf-mode-initialize systemd-comment-start)
   (setq-local auto-fill-inhibit-regexp "^[ \t]*?[^;#]")
-  (add-hook 'company-backends #'systemd-company-backend)
+  (make-local-variable 'company-backends)
+  (cl-pushnew 'company-capf company-backends)
+  ;; (add-hook 'company-backends #'systemd-company-backend)
   (add-hook 'completion-at-point-functions #'systemd-complete-at-point nil t)
   (add-hook 'font-lock-extend-region-functions
             'systemd-font-lock-extend-region nil t)


### PR DESCRIPTION
Hi, this just merges completion for environment variables with
the prior completion.  I also commented out the company backend
since `company-capf` should work just as well here AFAIC.