### PR TITLE
Fix txt file paths during native-compile-async

### DIFF
--- a/systemd.el
+++ b/systemd.el
@@ -88,7 +88,9 @@
     (with-temp-buffer
       (insert-file-contents
        (let ((f "unit-directives.txt"))
-         (if (null load-file-name) f
+         (if (or (null load-file-name)
+                 (bound-and-true-p comp-async-compilation))
+             f
            (expand-file-name f (file-name-directory load-file-name)))))
       (split-string (buffer-string))))
   "Configuration directives for systemd.")
@@ -107,7 +109,9 @@
     (with-temp-buffer
       (insert-file-contents
        (let ((f "network-directives.txt"))
-         (if (null load-file-name) f
+         (if (or (null load-file-name)
+                 (bound-and-true-p comp-async-compilation))
+             f
            (expand-file-name f (file-name-directory load-file-name)))))
       (split-string (buffer-string))))
   "Network configuration directives for systemd.")
@@ -121,7 +125,9 @@
     (with-temp-buffer
       (insert-file-contents
        (let ((f "nspawn-directives.txt"))
-         (if (null load-file-name) f
+         (if (or (null load-file-name)
+                 (bound-and-true-p comp-async-compilation))
+             f
            (expand-file-name f (file-name-directory load-file-name)))))
       (split-string (buffer-string))))
   "Namespace container configuration directives for systemd.")


### PR DESCRIPTION
Hey there, thanks for putting this mode up! I've been using it with native compilation recently, and noticed errors about missing files that only occur when native-compiling in async mode. This PR fixes up path name resolution for the `defconst` expressions.

----------------------------------

When building systemd.el with async native compile, we can't rely on
`load-file-name`, so fall back to the native relative path lookup performed
in `insert-file-contents`.

native-compile-async runs compilation in a subprocess launched by loading
an elisp program from a temporary file:

(native-compile-async "/home/phil/.emacs.d/systemd/systemd.el")
=> invokes
emacs --batch -l /tmp/emacs-async-comp-systemd-BZ3kNs.el

Inside the subprocess, `load-file-name` is
/tmp/emacs-async-comp-systemd-BZ3kNs.el instead of .../systemd/systemd.el and
the local txt resource files (unit-directives.txt etc) aren't resolvable from
/tmp.