### PR TITLE
Make complete function non-exclusive

### DIFF
--- a/systemd.el
+++ b/systemd.el
@@ -235,7 +235,8 @@ file, defaulting to the link under point, if any."
   (let ((bounds (bounds-of-thing-at-point 'symbol)))
     (list (or (car bounds) (point))
           (or (cdr bounds) (point))
-          (completion-table-dynamic #'systemd-completion-table))))
+          (completion-table-dynamic #'systemd-completion-table)
+          :exclusive 'no)))
 
 (defun systemd-company-backend (command &optional arg &rest _ignored)
   "Backend for `company-mode' in `systemd-mode' buffers."


### PR DESCRIPTION
This will allow other completion at point functions to run to autocomplete things like file path. Figured this out from https://github.com/minad/cape/issues/24